### PR TITLE
Version Update V0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - `monad_std.Option`, `monad_std.Result`:
     - Move `transpose`, `flatten`, `unzip` from `staticmethod` to object method.
 
+**Impl Change**
+
+- `monad_std.Option`:
+    - `__and__`, `__or__`, `__xor__` are not abstract methods now, and is implemented by `Option` itself.
+
 **DOCUMENTATION**
 
 - Move **STD Types** to one page.

--- a/docs_src/docs/CHANGELOG.md
+++ b/docs_src/docs/CHANGELOG.md
@@ -7,6 +7,11 @@
 - [`monad_std.Option`][monad_std.option.Option], [`monad_std.Result`][monad_std.result.Result]:
     - Move `transpose`, `flatten`, `unzip` from `staticmethod` to object method.
 
+**Impl Change**
+
+- [`monad_std.Option`][monad_std.option.Option]:
+    - [`__and__`][monad_std.option.Option.__and__], [`__or__`][monad_std.option.Option.__or__], [`__xor__`][monad_std.option.Option.__xor__] are not abstract methods now, and is implemented by [`Option`][monad_std.option.Option] itself.
+
 **DOCUMENTATION**
 
 - Move **STD Types** to one page.

--- a/monad_std/option.py
+++ b/monad_std/option.py
@@ -70,20 +70,26 @@ class Option(Generic[KT], metaclass=ABCMeta):
         """Alias `iter(self.to_array())`."""
         return iter(self.to_array())
 
-    @abstractmethod
     def __and__(self, other):
         """Alias [`bool_and`][monad_std.option.Option.bool_and]."""
-        ...
+        if isinstance(other, Option):
+            return self.bool_and(other)
+        else:
+            raise TypeError("expect another Option")
 
-    @abstractmethod
     def __or__(self, other):
         """Alias [`bool_or`][monad_std.option.Option.bool_or]."""
-        ...
+        if isinstance(other, Option):
+            return self.bool_or(other)
+        else:
+            raise TypeError("expect another Option")
 
-    @abstractmethod
     def __xor__(self, other):
         """Alias [`bool_xor`][monad_std.option.Option.bool_xor]."""
-        ...
+        if isinstance(other, Option):
+            return self.bool_xor(other)
+        else:
+            raise TypeError("expect another Option")
 
     @staticmethod
     def from_nullable(value: Optional[KT]) -> "Option[KT]":
@@ -666,27 +672,6 @@ class OpSome(Generic[KT], Option[KT]):
     def __hash__(self):
         return hash(self.__value)
 
-    def __and__(self, other):
-        if isinstance(other, Option):
-            return Option.clone(other)
-        else:
-            raise TypeError("expect another Option")
-
-    def __or__(self, other):
-        if isinstance(other, Option):
-            return self.clone()
-        else:
-            raise TypeError("expect another Option")
-
-    def __xor__(self, other):
-        if isinstance(other, Option):
-            if other.is_some():
-                return OpNone()
-            else:
-                return self.clone()
-        else:
-            raise TypeError("expect another Option")
-
     def clone(self):
         return OpSome(self.__value)
 
@@ -791,24 +776,6 @@ class OpNone(Generic[KT], Option[KT]):
 
     def __hash__(self):
         return hash(None)
-
-    def __and__(self, other):
-        if isinstance(other, Option):
-            return self
-        else:
-            raise TypeError("expect another Option")
-
-    def __or__(self, other):
-        if isinstance(other, Option):
-            return other.clone()
-        else:
-            raise TypeError("expect another Option")
-
-    def __xor__(self, other):
-        if isinstance(other, Option):
-            return other.clone()
-        else:
-            raise TypeError("expect another Option")
 
     def clone(self):
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monad-std"
-version = "0.2.0"
+version = "0.3.0"
 description = "A library of rust-styled monad utils for python."
 authors = ["Embers-of-the-Fire <stellarishs@163.com>"]
 homepage = "https://embers-of-the-fire.github.io/monad-std/"

--- a/tests/option_test.py
+++ b/tests/option_test.py
@@ -4,33 +4,54 @@ import monad_std
 
 
 class OptionTest(unittest.TestCase):
+    def test_build(self):
+        self.assertEqual(monad_std.Option.from_nullable(None), monad_std.Option.none())
+        self.assertEqual(monad_std.Option.from_nullable(2), monad_std.Option.some(2))
+
     def test_identify(self):
-        x: monad_std.option.Option[int] = monad_std.option.Option.some(2)
+        x: monad_std.Option[int] = monad_std.Option.some(2)
         self.assertTrue(x.is_some())
         self.assertFalse(x.is_none())
-        x: monad_std.option.Option[int] = monad_std.option.Option.none()
+        x: monad_std.Option[int] = monad_std.Option.none()
         self.assertFalse(x.is_some())
         self.assertTrue(x.is_none())
 
-        x: monad_std.option.Option[int] = monad_std.option.Option.some(2)
+        x: monad_std.Option[int] = monad_std.Option.some(2)
         self.assertTrue(x.is_some_and(lambda v: v > 1))
-        x: monad_std.option.Option[int] = monad_std.option.Option.some(0)
+        x: monad_std.Option[int] = monad_std.Option.some(0)
         self.assertFalse(x.is_some_and(lambda v: v > 1))
-        x: monad_std.option.Option[int] = monad_std.option.Option.none()
+        x: monad_std.Option[int] = monad_std.Option.none()
         self.assertFalse(x.is_some_and(lambda v: v > 1))
 
+    def test_magic_method(self):
+        self.assertTrue(monad_std.Option.some(2))
+        self.assertFalse(monad_std.Option.none())
+
+        self.assertEqual(monad_std.Option.some(2), monad_std.Option.some(1) + monad_std.Option.some(1))
+
+        self.assertEqual(monad_std.Option.some(4), monad_std.Option.some(2) * monad_std.Option.some(2))
+
+        self.assertEqual(hash(monad_std.Option.some(2)), hash(2))
+
+        v1 = monad_std.Option.some(2)
+        v2 = monad_std.Option.some(4)
+
+        self.assertEqual(v1 & v2, v1.bool_and(v2))
+        self.assertEqual(v1 | v2, v1.bool_or(v2))
+        self.assertEqual(v1 ^ v2, v1.bool_xor(v2))
+
     def test_unwrap(self):
-        x: monad_std.option.Option[str] = monad_std.option.Option.some("value")
+        x: monad_std.Option[str] = monad_std.Option.some("value")
         self.assertEqual(x.expect("hey, this is an `Option::None` object"), "value")
-        x: monad_std.option.Option[str] = monad_std.option.Option.none()
+        x: monad_std.Option[str] = monad_std.Option.none()
         try:
             x.expect("hey, this is an `Option::None` object")
         except monad_std.UnwrapException as e:
             self.assertEqual(str(e), "OptionError: hey, this is an `Option::None` object")
 
-        x: monad_std.option.Option[str] = monad_std.option.Option.some("air")
+        x: monad_std.Option[str] = monad_std.Option.some("air")
         self.assertEqual(x.unwrap(), "air")
-        x: monad_std.option.Option[str] = monad_std.option.Option.none()
+        x: monad_std.Option[str] = monad_std.Option.none()
         try:
             x.unwrap()
         except monad_std.UnwrapException as e:
@@ -39,245 +60,241 @@ class OptionTest(unittest.TestCase):
                 "OptionError: call `Option.unwrap` on an " "`Option::None` object",
             )
 
-        self.assertEqual(monad_std.option.Option.some("car").unwrap_or("bike"), "car")
-        self.assertEqual(monad_std.option.Option.none().unwrap_or("bike"), "bike")
+        self.assertEqual(monad_std.Option.some("car").unwrap_or("bike"), "car")
+        self.assertEqual(monad_std.Option.none().unwrap_or("bike"), "bike")
 
         k = 10
-        self.assertEqual(monad_std.option.Option.some(4).unwrap_or_else(lambda: 2 * k), 4)
-        self.assertEqual(monad_std.option.Option.none().unwrap_or_else(lambda: 2 * k), 20)
+        self.assertEqual(monad_std.Option.some(4).unwrap_or_else(lambda: 2 * k), 4)
+        self.assertEqual(monad_std.Option.none().unwrap_or_else(lambda: 2 * k), 20)
 
-        self.assertEqual(monad_std.option.Option.some(4).unwrap_unchecked(), 4)
-        self.assertTrue(monad_std.option.Option.none().unwrap_unchecked() is None)
+        self.assertEqual(monad_std.Option.some(4).unwrap_unchecked(), 4)
+        self.assertTrue(monad_std.Option.none().unwrap_unchecked() is None)
 
     def test_map(self):
         x = []
-        monad_std.option.Option.some(2).inspect(lambda s: x.append(s))
+        monad_std.Option.some(2).inspect(lambda s: x.append(s))
         self.assertListEqual(x, [2])
-        monad_std.option.Option.none().inspect(lambda s: x.append(s))
+        monad_std.Option.none().inspect(lambda s: x.append(s))
         self.assertListEqual(x, [2])
 
-        maybe_some_string = monad_std.option.Option.some("Hello, World!")
+        maybe_some_string = monad_std.Option.some("Hello, World!")
         maybe_some_len = maybe_some_string.map(lambda s: len(s))
-        self.assertEqual(maybe_some_len, monad_std.option.Option.some(13))
+        self.assertEqual(maybe_some_len, monad_std.Option.some(13))
         self.assertEqual(
-            monad_std.option.Option.none().map(lambda s: len(s)),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().map(lambda s: len(s)),
+            monad_std.Option.none(),
         )
 
         self.assertEqual(
-            monad_std.option.Option.some("foo").map_or(42, lambda s: len(s)),
+            monad_std.Option.some("foo").map_or(42, lambda s: len(s)),
             3,
         )
-        self.assertEqual(monad_std.option.Option.none().map_or(42, lambda s: len(s)), 42)
+        self.assertEqual(monad_std.Option.none().map_or(42, lambda s: len(s)), 42)
 
         k = 21
         self.assertEqual(
-            monad_std.option.Option.some("bar").map_or_else(lambda: 2 * k, lambda s: len(s)),
+            monad_std.Option.some("bar").map_or_else(lambda: 2 * k, lambda s: len(s)),
             3,
         )
         self.assertEqual(
-            monad_std.option.Option.none().map_or_else(lambda: 2 * k, lambda s: len(s)),
+            monad_std.Option.none().map_or_else(lambda: 2 * k, lambda s: len(s)),
             42,
         )
 
     def test_into_result(self):
         self.assertEqual(
-            monad_std.option.Option.some("foo").ok_or(0),
-            monad_std.result.Result.of_ok("foo"),
+            monad_std.Option.some("foo").ok_or(0),
+            monad_std.Result.of_ok("foo"),
         )
         self.assertEqual(
-            monad_std.option.Option.none().ok_or(0),
-            monad_std.result.Result.of_err(0),
+            monad_std.Option.none().ok_or(0),
+            monad_std.Result.of_err(0),
         )
 
         k = 21
         self.assertEqual(
-            monad_std.option.Option.some("foo").ok_or_else(lambda: k * 2),
-            monad_std.result.Result.of_ok("foo"),
+            monad_std.Option.some("foo").ok_or_else(lambda: k * 2),
+            monad_std.Result.of_ok("foo"),
         )
         self.assertEqual(
-            monad_std.option.Option.none().ok_or_else(lambda: k * 2),
-            monad_std.result.Result.of_err(42),
+            monad_std.Option.none().ok_or_else(lambda: k * 2),
+            monad_std.Result.of_err(42),
         )
 
     def test_to_array(self):
-        self.assertListEqual(monad_std.option.Option.some(1).to_array(), [1])
-        self.assertListEqual(monad_std.option.Option.none().to_array(), [])
+        self.assertListEqual(monad_std.Option.some(1).to_array(), [1])
+        self.assertListEqual(monad_std.Option.none().to_array(), [])
 
     def test_bool_eval(self):
         self.assertEqual(
-            monad_std.option.Option.some(2).bool_and(monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(2).bool_and(monad_std.Option.none()),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.none().bool_and(monad_std.option.Option.some("foo")),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().bool_and(monad_std.Option.some("foo")),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.some(2).bool_and(monad_std.option.Option.some("bar")),
-            monad_std.option.Option.some("bar"),
+            monad_std.Option.some(2).bool_and(monad_std.Option.some("bar")),
+            monad_std.Option.some("bar"),
         )
         self.assertEqual(
-            monad_std.option.Option.none().bool_and(monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
-        )
-
-        self.assertEqual(
-            monad_std.option.Option.some(2).bool_or(monad_std.option.Option.none()),
-            monad_std.option.Option.some(2),
-        )
-        self.assertEqual(
-            monad_std.option.Option.none().bool_or(monad_std.option.Option.some(100)),
-            monad_std.option.Option.some(100),
-        )
-        self.assertEqual(
-            monad_std.option.Option.some(2).bool_or(monad_std.option.Option.some(100)),
-            monad_std.option.Option.some(2),
-        )
-        self.assertEqual(
-            monad_std.option.Option.none().bool_or(monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().bool_and(monad_std.Option.none()),
+            monad_std.Option.none(),
         )
 
         self.assertEqual(
-            monad_std.option.Option.some(2).bool_xor(monad_std.option.Option.none()),
-            monad_std.option.Option.some(2),
+            monad_std.Option.some(2).bool_or(monad_std.Option.none()),
+            monad_std.Option.some(2),
         )
         self.assertEqual(
-            monad_std.option.Option.none().bool_xor(monad_std.option.Option.some(2)),
-            monad_std.option.Option.some(2),
+            monad_std.Option.none().bool_or(monad_std.Option.some(100)),
+            monad_std.Option.some(100),
         )
         self.assertEqual(
-            monad_std.option.Option.some(2).bool_xor(monad_std.option.Option.some(2)),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(2).bool_or(monad_std.Option.some(100)),
+            monad_std.Option.some(2),
         )
         self.assertEqual(
-            monad_std.option.Option.none().bool_xor(monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().bool_or(monad_std.Option.none()),
+            monad_std.Option.none(),
+        )
+
+        self.assertEqual(
+            monad_std.Option.some(2).bool_xor(monad_std.Option.none()),
+            monad_std.Option.some(2),
+        )
+        self.assertEqual(
+            monad_std.Option.none().bool_xor(monad_std.Option.some(2)),
+            monad_std.Option.some(2),
+        )
+        self.assertEqual(
+            monad_std.Option.some(2).bool_xor(monad_std.Option.some(2)),
+            monad_std.Option.none(),
+        )
+        self.assertEqual(
+            monad_std.Option.none().bool_xor(monad_std.Option.none()),
+            monad_std.Option.none(),
         )
 
     def test_chain(self):
         self.assertEqual(
-            monad_std.option.Option.some(2).and_then(lambda x: monad_std.option.Option.some(str(x))),
-            monad_std.option.Option.some("2"),
+            monad_std.Option.some(2).and_then(lambda x: monad_std.Option.some(str(x))),
+            monad_std.Option.some("2"),
         )
         self.assertEqual(
-            monad_std.option.Option.some(10).and_then(lambda _: monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(10).and_then(lambda _: monad_std.Option.none()),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.none().and_then(lambda x: monad_std.option.Option.some(str(x))),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().and_then(lambda x: monad_std.Option.some(str(x))),
+            monad_std.Option.none(),
         )
 
         def get_from(l, i):
             try:
-                return monad_std.option.Option.some(l[i])
+                return monad_std.Option.some(l[i])
             except IndexError:
-                return monad_std.option.Option.none()
+                return monad_std.Option.none()
 
         arr2d = [["A0", "A1"], ["B0", "B1"]]
         self.assertEqual(
             get_from(arr2d, 0).and_then(lambda row: get_from(row, 1)),
-            monad_std.option.Option.some("A1"),
+            monad_std.Option.some("A1"),
         )
         self.assertEqual(
             get_from(arr2d, 2).and_then(lambda row: get_from(row, 0)),
-            monad_std.option.Option.none(),
+            monad_std.Option.none(),
         )
 
         self.assertEqual(
-            monad_std.option.Option.some("foo").or_else(lambda: monad_std.option.Option.some("bar")),
-            monad_std.option.Option.some("foo"),
+            monad_std.Option.some("foo").or_else(lambda: monad_std.Option.some("bar")),
+            monad_std.Option.some("foo"),
         )
         self.assertEqual(
-            monad_std.option.Option.none().or_else(lambda: monad_std.option.Option.some("bar")),
-            monad_std.option.Option.some("bar"),
+            monad_std.Option.none().or_else(lambda: monad_std.Option.some("bar")),
+            monad_std.Option.some("bar"),
         )
         self.assertEqual(
-            monad_std.option.Option.none().or_else(lambda: monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
-        )
-
-        self.assertEqual(
-            monad_std.option.Option.none().filter(lambda n: n % 2 == 0),
-            monad_std.option.Option.none(),
-        )
-        self.assertEqual(
-            monad_std.option.Option.some(3).filter(lambda n: n % 2 == 0),
-            monad_std.option.Option.none(),
-        )
-        self.assertEqual(
-            monad_std.option.Option.some(4).filter(lambda n: n % 2 == 0),
-            monad_std.option.Option.some(4),
+            monad_std.Option.none().or_else(lambda: monad_std.Option.none()),
+            monad_std.Option.none(),
         )
 
         self.assertEqual(
-            monad_std.option.Option.some(1).zip(monad_std.option.Option.some("hi")),
-            monad_std.option.Option.some((1, "hi")),
+            monad_std.Option.none().filter(lambda n: n % 2 == 0),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.some(1).zip(monad_std.option.Option.none()),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(3).filter(lambda n: n % 2 == 0),
+            monad_std.Option.none(),
+        )
+        self.assertEqual(
+            monad_std.Option.some(4).filter(lambda n: n % 2 == 0),
+            monad_std.Option.some(4),
+        )
+
+        self.assertEqual(
+            monad_std.Option.some(1).zip(monad_std.Option.some("hi")),
+            monad_std.Option.some((1, "hi")),
+        )
+        self.assertEqual(
+            monad_std.Option.some(1).zip(monad_std.Option.none()),
+            monad_std.Option.none(),
         )
 
         def make_point(x, y):
-            return monad_std.option.Option.some({"x": x, "y": y})
+            return monad_std.Option.some({"x": x, "y": y})
 
         self.assertEqual(
-            monad_std.option.Option.some(2).zip_with(monad_std.option.Option.some(4), make_point),
-            monad_std.option.Option.some({"x": 2, "y": 4}),
+            monad_std.Option.some(2).zip_with(monad_std.Option.some(4), make_point),
+            monad_std.Option.some({"x": 2, "y": 4}),
         )
         self.assertEqual(
-            monad_std.option.Option.some(2).zip_with(monad_std.option.Option.none(), make_point),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(2).zip_with(monad_std.Option.none(), make_point),
+            monad_std.Option.none(),
         )
 
     def test_unzip(self):
         self.assertTupleEqual(
-            monad_std.option.Option.some((1, "hi")).unzip(),
+            monad_std.Option.some((1, "hi")).unzip(),
             (
-                monad_std.option.Option.some(1),
-                monad_std.option.Option.some("hi"),
+                monad_std.Option.some(1),
+                monad_std.Option.some("hi"),
             ),
         )
         self.assertTupleEqual(
-            monad_std.option.Option.none().unzip(),
+            monad_std.Option.none().unzip(),
             (
-                monad_std.option.Option.none(),
-                monad_std.option.Option.none(),
+                monad_std.Option.none(),
+                monad_std.Option.none(),
             ),
         )
 
     def test_transpose(self):
-        x = monad_std.result.Result.of_ok(monad_std.option.Option.some(5))
-        y = monad_std.option.Option.some(monad_std.result.Result.of_ok(5))
+        x = monad_std.Result.of_ok(monad_std.Option.some(5))
+        y = monad_std.Option.some(monad_std.Result.of_ok(5))
         self.assertEqual(x, y.transpose())
 
     def test_flatten(self):
         self.assertEqual(
-            monad_std.option.Option.some(monad_std.option.Option.some(6)).flatten(),
-            monad_std.option.Option.some(6),
+            monad_std.Option.some(monad_std.Option.some(6)).flatten(),
+            monad_std.Option.some(6),
         )
         self.assertEqual(
-            monad_std.option.Option.some(monad_std.option.Option.none()).flatten(),
-            monad_std.option.Option.none(),
+            monad_std.Option.some(monad_std.Option.none()).flatten(),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.none().flatten(),
-            monad_std.option.Option.none(),
+            monad_std.Option.none().flatten(),
+            monad_std.Option.none(),
         )
         self.assertEqual(
-            monad_std.option.Option.some(
-                monad_std.option.Option.some(monad_std.option.Option.some(6))
-            ).flatten(),
-            monad_std.option.Option.some(monad_std.option.Option.some(6)),
+            monad_std.Option.some(monad_std.Option.some(monad_std.Option.some(6))).flatten(),
+            monad_std.Option.some(monad_std.Option.some(6)),
         )
         self.assertEqual(
-            monad_std.option.Option.some(monad_std.option.Option.some(monad_std.option.Option.some(6)))
-            .flatten()
-            .flatten(),
-            monad_std.option.Option.some(6),
+            monad_std.Option.some(monad_std.Option.some(monad_std.Option.some(6))).flatten().flatten(),
+            monad_std.Option.some(6),
         )
 
 

--- a/tests/result_test.py
+++ b/tests/result_test.py
@@ -5,18 +5,32 @@ import monad_std
 
 class ResultTest(unittest.TestCase):
     def test_identify(self):
-        self.assertTrue(monad_std.result.Result.of_ok(2).is_ok())
-        self.assertFalse(monad_std.result.Result.of_ok(2).is_err())
-        self.assertFalse(monad_std.result.Result.of_err("err").is_ok())
-        self.assertTrue(monad_std.result.Result.of_err("err").is_err())
+        self.assertTrue(monad_std.Result.of_ok(2).is_ok())
+        self.assertFalse(monad_std.Result.of_ok(2).is_err())
+        self.assertFalse(monad_std.Result.of_err("err").is_ok())
+        self.assertTrue(monad_std.Result.of_err("err").is_err())
 
-        self.assertTrue(monad_std.result.Result.of_ok(2).is_ok_and(lambda x: x > 1))
-        self.assertFalse(monad_std.result.Result.of_ok(0).is_ok_and(lambda x: x > 1))
-        self.assertFalse(monad_std.result.Result.of_err("error").is_ok_and(lambda x: x > 1))
+        self.assertTrue(monad_std.Result.of_ok(2).is_ok_and(lambda x: x > 1))
+        self.assertFalse(monad_std.Result.of_ok(0).is_ok_and(lambda x: x > 1))
+        self.assertFalse(monad_std.Result.of_err("error").is_ok_and(lambda x: x > 1))
 
-        self.assertFalse(monad_std.result.Result.of_ok(2).is_err_and(lambda x: len(x) == 3))
-        self.assertTrue(monad_std.result.Result.of_err("err").is_err_and(lambda x: len(x) == 3))
-        self.assertFalse(monad_std.result.Result.of_err("error").is_err_and(lambda x: len(x) == 3))
+        self.assertFalse(monad_std.Result.of_ok(2).is_err_and(lambda x: len(x) == 3))
+        self.assertTrue(monad_std.Result.of_err("err").is_err_and(lambda x: len(x) == 3))
+        self.assertFalse(monad_std.Result.of_err("error").is_err_and(lambda x: len(x) == 3))
+
+    def test_magic_method(self):
+        self.assertTrue(monad_std.Ok(2))
+        self.assertFalse(monad_std.Err("err"))
+
+        self.assertEqual(monad_std.Ok(2), monad_std.Ok(1) + monad_std.Ok(1))
+
+        self.assertEqual(monad_std.Ok(4), monad_std.Ok(2) * monad_std.Ok(2))
+
+        v1 = monad_std.Ok(2)
+        v2 = monad_std.Err('err')
+
+        self.assertEqual(v1 & v2, v1.bool_and(v2))
+        self.assertEqual(v1 | v2, v1.bool_or(v2))
 
     def test_catch(self):
         def maybe_error(v: int) -> int:
@@ -26,233 +40,233 @@ class ResultTest(unittest.TestCase):
                 raise ValueError()
 
         self.assertEqual(
-            monad_std.result.Result.catch(lambda: maybe_error(2)),
-            monad_std.result.Result.of_ok(3),
+            monad_std.Result.catch(lambda: maybe_error(2)),
+            monad_std.Result.of_ok(3),
         )
         self.assertIsInstance(
-            monad_std.result.Result.catch(lambda: maybe_error(3)).unwrap_err(),
+            monad_std.Result.catch(lambda: maybe_error(3)).unwrap_err(),
             ValueError,
         )
 
         self.assertEqual(
-            monad_std.result.Result.catch_from(maybe_error, v=2),
-            monad_std.result.Result.of_ok(3),
+            monad_std.Result.catch_from(maybe_error, v=2),
+            monad_std.Result.of_ok(3),
         )
         self.assertIsInstance(
-            monad_std.result.Result.catch_from(maybe_error, 3).unwrap_err(),
+            monad_std.Result.catch_from(maybe_error, 3).unwrap_err(),
             ValueError,
         )
 
     def test_into_option(self):
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).ok(),
-            monad_std.option.Option.some(2),
+            monad_std.Result.of_ok(2).ok(),
+            monad_std.Option.some(2),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("err").ok(),
-            monad_std.option.Option.none(),
+            monad_std.Result.of_err("err").ok(),
+            monad_std.Option.none(),
         )
 
         self.assertEqual(
-            monad_std.result.Result.of_err("err").err(),
-            monad_std.option.Option.some("err"),
+            monad_std.Result.of_err("err").err(),
+            monad_std.Option.some("err"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_ok(0).err(),
-            monad_std.option.Option.none(),
+            monad_std.Result.of_ok(0).err(),
+            monad_std.Option.none(),
         )
 
     def test_mapping(self):
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).map(lambda x: x * 2),
-            monad_std.result.Result.of_ok(4),
+            monad_std.Result.of_ok(2).map(lambda x: x * 2),
+            monad_std.Result.of_ok(4),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("err").map(lambda x: x * 2),
-            monad_std.result.Result.of_err("err"),
+            monad_std.Result.of_err("err").map(lambda x: x * 2),
+            monad_std.Result.of_err("err"),
         )
 
-        self.assertEqual(monad_std.result.Result.of_ok("foo").map_or(42, lambda s: len(s)), 3)
+        self.assertEqual(monad_std.Result.of_ok("foo").map_or(42, lambda s: len(s)), 3)
         self.assertEqual(
-            monad_std.result.Result.of_err("bar").map_or(42, lambda s: len(s)),
+            monad_std.Result.of_err("bar").map_or(42, lambda s: len(s)),
             42,
         )
 
         self.assertEqual(
-            monad_std.result.Result.of_ok("foo").map_or_else(lambda e: len(e) + 3, lambda v: len(v)),
+            monad_std.Result.of_ok("foo").map_or_else(lambda e: len(e) + 3, lambda v: len(v)),
             3,
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("bar").map_or_else(lambda e: len(e) + 3, lambda v: len(v)),
+            monad_std.Result.of_err("bar").map_or_else(lambda e: len(e) + 3, lambda v: len(v)),
             6,
         )
 
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).map_err(lambda x: str(x)),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_ok(2).map_err(lambda x: str(x)),
+            monad_std.Result.of_ok(2),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err(-1).map_err(lambda x: str(x)),
-            monad_std.result.Result.of_err("-1"),
+            monad_std.Result.of_err(-1).map_err(lambda x: str(x)),
+            monad_std.Result.of_err("-1"),
         )
 
     def test_inspect(self):
         k = []
-        monad_std.result.Result.of_ok(2).inspect(lambda x: k.append(x))
+        monad_std.Result.of_ok(2).inspect(lambda x: k.append(x))
         self.assertListEqual(k, [2])
-        monad_std.result.Result.of_err("err").inspect(lambda x: k.append(x))
+        monad_std.Result.of_err("err").inspect(lambda x: k.append(x))
         self.assertListEqual(k, [2])
 
         k = []
-        monad_std.result.Result.of_ok(2).inspect_err(lambda x: k.append(x))
+        monad_std.Result.of_ok(2).inspect_err(lambda x: k.append(x))
         self.assertListEqual(k, [])
-        monad_std.result.Result.of_err(-1).inspect_err(lambda x: k.append(x))
+        monad_std.Result.of_err(-1).inspect_err(lambda x: k.append(x))
         self.assertListEqual(k, [-1])
 
     def test_to_array(self):
-        self.assertListEqual(monad_std.result.Result.of_ok(2).to_array(), [2])
-        self.assertListEqual(monad_std.result.Result.of_err("err").to_array(), [])
+        self.assertListEqual(monad_std.Result.of_ok(2).to_array(), [2])
+        self.assertListEqual(monad_std.Result.of_err("err").to_array(), [])
 
     def test_unwrap(self):
-        self.assertEqual(monad_std.result.Result.of_ok(2).expect("error"), 2)
+        self.assertEqual(monad_std.Result.of_ok(2).expect("error"), 2)
         try:
-            monad_std.result.Result.of_err("err").expect("error")
+            monad_std.Result.of_err("err").expect("error")
         except monad_std.UnwrapException as e:
             self.assertEqual(str(e), "ResultError: error: 'err'")
 
-        self.assertEqual(monad_std.result.Result.of_err("err").expect_err("ok"), "err")
+        self.assertEqual(monad_std.Result.of_err("err").expect_err("ok"), "err")
         try:
-            monad_std.result.Result.of_ok(2).expect_err("ok")
+            monad_std.Result.of_ok(2).expect_err("ok")
         except monad_std.UnwrapException as e:
             self.assertEqual(str(e), "ResultError: ok: 2")
 
-        self.assertEqual(monad_std.result.Result.of_ok(2).unwrap(), 2)
+        self.assertEqual(monad_std.Result.of_ok(2).unwrap(), 2)
         try:
-            monad_std.result.Result.of_err("err").unwrap()
+            monad_std.Result.of_err("err").unwrap()
         except monad_std.UnwrapException as e:
             self.assertEqual(
                 str(e),
                 "ResultError: call `Result.unwrap` on an `Err` value: 'err'",
             )
 
-        self.assertEqual(monad_std.result.Result.of_err("err").unwrap_err(), "err")
+        self.assertEqual(monad_std.Result.of_err("err").unwrap_err(), "err")
         try:
-            monad_std.result.Result.of_ok(2).unwrap_err()
+            monad_std.Result.of_ok(2).unwrap_err()
         except monad_std.UnwrapException as e:
             self.assertEqual(
                 str(e),
                 "ResultError: call `Result.unwrap_err` on an `Ok` value: 2",
             )
 
-        self.assertEqual(monad_std.result.Result.of_ok(9).unwrap_or(2), 9)
-        self.assertEqual(monad_std.result.Result.of_err("err").unwrap_or(2), 2)
+        self.assertEqual(monad_std.Result.of_ok(9).unwrap_or(2), 9)
+        self.assertEqual(monad_std.Result.of_err("err").unwrap_or(2), 2)
 
-        self.assertEqual(monad_std.result.Result.of_ok(2).unwrap_or_else(lambda s: len(s)), 2)
+        self.assertEqual(monad_std.Result.of_ok(2).unwrap_or_else(lambda s: len(s)), 2)
         self.assertEqual(
-            monad_std.result.Result.of_err("foo").unwrap_or_else(lambda s: len(s)),
+            monad_std.Result.of_err("foo").unwrap_or_else(lambda s: len(s)),
             3,
         )
 
     def test_bool(self):
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).bool_and(monad_std.result.Result.of_err("late error")),
-            monad_std.result.Result.of_err("late error"),
+            monad_std.Result.of_ok(2).bool_and(monad_std.Result.of_err("late error")),
+            monad_std.Result.of_err("late error"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("early error").bool_and(monad_std.result.Result.of_ok(2)),
-            monad_std.result.Result.of_err("early error"),
+            monad_std.Result.of_err("early error").bool_and(monad_std.Result.of_ok(2)),
+            monad_std.Result.of_err("early error"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("early error").bool_and(monad_std.result.Result.of_err("late error")),
-            monad_std.result.Result.of_err("early error"),
+            monad_std.Result.of_err("early error").bool_and(monad_std.Result.of_err("late error")),
+            monad_std.Result.of_err("early error"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).bool_and(monad_std.result.Result.of_ok("another ok")),
-            monad_std.result.Result.of_ok("another ok"),
+            monad_std.Result.of_ok(2).bool_and(monad_std.Result.of_ok("another ok")),
+            monad_std.Result.of_ok("another ok"),
         )
 
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).bool_or(monad_std.result.Result.of_err("late error")),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_ok(2).bool_or(monad_std.Result.of_err("late error")),
+            monad_std.Result.of_ok(2),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("early error").bool_or(monad_std.result.Result.of_ok(2)),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_err("early error").bool_or(monad_std.Result.of_ok(2)),
+            monad_std.Result.of_ok(2),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("early error").bool_or(monad_std.result.Result.of_err("late error")),
-            monad_std.result.Result.of_err("late error"),
+            monad_std.Result.of_err("early error").bool_or(monad_std.Result.of_err("late error")),
+            monad_std.Result.of_err("late error"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).bool_or(monad_std.result.Result.of_ok(100)),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_ok(2).bool_or(monad_std.Result.of_ok(100)),
+            monad_std.Result.of_ok(2),
         )
 
     def test_chain(self):
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).and_then(lambda n: monad_std.result.Result.of_ok(n * 2)),
-            monad_std.result.Result.of_ok(4),
+            monad_std.Result.of_ok(2).and_then(lambda n: monad_std.Result.of_ok(n * 2)),
+            monad_std.Result.of_ok(4),
         )
         self.assertEqual(
-            monad_std.result.Result.of_ok(2).and_then(lambda _: monad_std.result.Result.of_err("err")),
-            monad_std.result.Result.of_err("err"),
+            monad_std.Result.of_ok(2).and_then(lambda _: monad_std.Result.of_err("err")),
+            monad_std.Result.of_err("err"),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err("err").and_then(lambda n: monad_std.result.Result.of_ok(n * 2)),
-            monad_std.result.Result.of_err("err"),
+            monad_std.Result.of_err("err").and_then(lambda n: monad_std.Result.of_ok(n * 2)),
+            monad_std.Result.of_err("err"),
         )
 
-        def square(v: int) -> monad_std.result.Result[int, int]:
-            return monad_std.result.Result.of_ok(v * v)
+        def square(v: int) -> monad_std.Result[int, int]:
+            return monad_std.Result.of_ok(v * v)
 
-        def err(v: int) -> monad_std.result.Result[int, int]:
-            return monad_std.result.Result.of_err(v)
+        def err(v: int) -> monad_std.Result[int, int]:
+            return monad_std.Result.of_err(v)
 
-        x: monad_std.result.Result[int, int] = monad_std.result.Result.of_ok(2)
+        x: monad_std.Result[int, int] = monad_std.Result.of_ok(2)
         self.assertEqual(
             x.or_else(square).or_else(square),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_ok(2),
         )
         self.assertEqual(
             x.or_else(err).or_else(square),
-            monad_std.result.Result.of_ok(2),
+            monad_std.Result.of_ok(2),
         )
 
-        x: monad_std.result.Result[int, int] = monad_std.result.Result.of_err(3)
+        x: monad_std.Result[int, int] = monad_std.Result.of_err(3)
         self.assertEqual(
             x.or_else(square).or_else(err),
-            monad_std.result.Result.of_ok(9),
+            monad_std.Result.of_ok(9),
         )
         self.assertEqual(
             x.or_else(err).or_else(err),
-            monad_std.result.Result.of_err(3),
+            monad_std.Result.of_err(3),
         )
 
     def test_transpose(self):
-        x = monad_std.result.Result.of_ok(monad_std.option.Option.some(5))
-        y = monad_std.option.Option.some(monad_std.result.Result.of_ok(5))
+        x = monad_std.Result.of_ok(monad_std.Option.some(5))
+        y = monad_std.Option.some(monad_std.Result.of_ok(5))
         self.assertEqual(x.transpose(), y)
 
     def test_flatten(self):
         self.assertEqual(
-            monad_std.result.Result.of_ok("hello"),
-            monad_std.result.Result.of_ok(monad_std.result.Result.of_ok("hello")).flatten(),
+            monad_std.Result.of_ok("hello"),
+            monad_std.Result.of_ok(monad_std.Result.of_ok("hello")).flatten(),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err(6),
-            monad_std.result.Result.of_ok(monad_std.result.Result.of_err(6)).flatten(),
+            monad_std.Result.of_err(6),
+            monad_std.Result.of_ok(monad_std.Result.of_err(6)).flatten(),
         )
         self.assertEqual(
-            monad_std.result.Result.of_err(5),
-            monad_std.result.Result.of_err(5).flatten(),
+            monad_std.Result.of_err(5),
+            monad_std.Result.of_err(5).flatten(),
         )
-        x = monad_std.result.Result.of_ok(monad_std.result.Result.of_ok(monad_std.result.Result.of_ok("hello")))
+        x = monad_std.Result.of_ok(monad_std.Result.of_ok(monad_std.Result.of_ok("hello")))
         self.assertEqual(
-            monad_std.result.Result.of_ok(monad_std.result.Result.of_ok("hello")),
+            monad_std.Result.of_ok(monad_std.Result.of_ok("hello")),
             x.flatten(),
         )
         self.assertEqual(
-            monad_std.result.Result.of_ok("hello"),
+            monad_std.Result.of_ok("hello"),
             x.flatten().flatten(),
         )
 


### PR DESCRIPTION
**Breaking Change**

- `monad_std.Option`, `monad_std.Result`:
    - Move `transpose`, `flatten`, `unzip` from `staticmethod` to object method.

**Impl Change**

- `monad_std.Option`:
    - `__and__`, `__or__`, `__xor__` are not abstract methods now, and is implemented by `Option` itself.

**DOCUMENTATION**

- Move **STD Types** to one page.
- Add overview for API documentation.
- Add a quick start guide.