### PR TITLE
Version Update V0.4.0

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## V0.4.0
+
+**ADD**
+
+- `monad_std.Option`:
+    - `to_nullable`/`unwrap_unchecked`: Convert `Option[T]` to `Optional[T]`.
+- `monad_std.Result`:
+    - `unwrap_unchecked`: Convert `Result[T, E]` to `Union[T, E]`.
+
 ## V0.3.0
 
 **Breaking Change**

--- a/docs_src/docs/CHANGELOG.md
+++ b/docs_src/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## V0.4.0
+
+**ADD**
+
+- [`monad_std.Option`][monad_std.option.Option]:
+    - [`to_nullable`][monad_std.option.Option.to_nullable]
+      /[`unwrap_unchecked`][monad_std.option.Option.unwrap_unchecked]: Convert `Option[T]` to `Optional[T]`.
+- [`monad_std.Result`][monad_std.result.Result]:
+    - [`unwrap_unchecked`][monad_std.result.Result.unwrap_unchecked]: Convert `Result[T, E]` to `Union[T, E]`.
+
 ## V0.3.0
 
 **Breaking Change**

--- a/docs_src/mkdocs.yml
+++ b/docs_src/mkdocs.yml
@@ -20,7 +20,7 @@ markdown_extensions:
 extra_javascript:
   - init.js
 nav:
-  - Intro: index.md
+  - Introduction: index.md
   - Quick Start: "quick start.md"
   - Api:
       - "Api Document/api overview.md"

--- a/monad_std/option.py
+++ b/monad_std/option.py
@@ -218,6 +218,33 @@ class Option(Generic[KT], metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def to_nullable(self) -> Optional[KT]:
+        """Returns the contained value. If `self` is an `Option::None`, this will return Python's `None` directly.
+
+        **Note**: If the wrapped object is `None` itself, this will also return `None` as it's wrapped by the `Some`.
+        It's impossible to distinguish between `Option::Some(None)` and `Option::None` by using this method.
+
+        Returns:
+            The contained value.
+
+        Examples:
+            ```python
+            x: Option[str] = Option.some("air")
+            assert x.to_nullable() == "air"
+            x: Option[str] = Option.none()
+            assert x.to_nullable() is None
+            x: Option[None] = Option.some(None)
+            assert x.to_nullable() is None
+            ```
+        """
+        ...
+
+    @abstractmethod
+    def unwrap_unchecked(self) -> Optional[KT]:
+        """This is the same as [`Option.to_nullable()`][monad_std.option.Option.to_nullable]."""
+        ...
+
+    @abstractmethod
     def unwrap(self) -> KT:
         """Returns the contained `Some` value.
 
@@ -687,6 +714,9 @@ class OpSome(Generic[KT], Option[KT]):
     def expect(self, msg: str) -> KT:
         return self.__value
 
+    def to_nullable(self) -> Optional[KT]:
+        return self.__value
+
     def unwrap(self) -> KT:
         return self.__value
 
@@ -791,6 +821,9 @@ class OpNone(Generic[KT], Option[KT]):
 
     def expect(self, msg: str) -> KT:
         raise UnwrapException("Option", msg)
+
+    def to_nullable(self) -> Optional[KT]:
+        return None
 
     def unwrap(self) -> KT:
         raise UnwrapException("Option", "call `Option.unwrap` on an `Option::None` object")

--- a/monad_std/result.py
+++ b/monad_std/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar, Callable, List, Any, Iterator
+from typing import Generic, TypeVar, Callable, List, Any, Iterator, Union
 from abc import ABCMeta, abstractmethod
 
 from .error import UnwrapException
@@ -401,6 +401,17 @@ class Result(Generic[KT, KE], metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def unwrap_unchecked(self) -> Union[KT, KE]:
+        """Returns the contained value, no matter what it is.
+
+        Examples:
+            ```python
+            assert Ok("foo").unwrap_unchecked() == Err("foo").unwrap_unchecked()
+            ```
+        """
+        ...
+
+    @abstractmethod
     def unwrap(self) -> KT:
         """Returns the contained `Ok` value.
 
@@ -667,6 +678,9 @@ class Ok(Generic[KT, KE], Result[KT, KE]):
     def expect_err(self, msg: str) -> KE:
         raise UnwrapException("Result", msg + f': {repr(self.__value)}')
 
+    def unwrap_unchecked(self) -> Union[KT, KE]:
+        return self.__value
+
     def unwrap(self) -> KT:
         return self.__value
 
@@ -757,6 +771,9 @@ class Err(Generic[KT, KE], Result[KT, KE]):
         raise UnwrapException("Result", msg + f': {repr(self.__value)}')
 
     def expect_err(self, msg: str) -> KE:
+        return self.__value
+
+    def unwrap_unchecked(self) -> Union[KT, KE]:
         return self.__value
 
     def unwrap(self) -> KT:

--- a/tests/option_test.py
+++ b/tests/option_test.py
@@ -70,6 +70,13 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(monad_std.Option.some(4).unwrap_unchecked(), 4)
         self.assertTrue(monad_std.Option.none().unwrap_unchecked() is None)
 
+        x: monad_std.Option[str] = monad_std.Option.some("air")
+        self.assertEqual(x.to_nullable(), "air")
+        x: monad_std.Option[str] = monad_std.Option.none()
+        self.assertIsNone(x.to_nullable())
+        x: monad_std.Option[None] = monad_std.Option.some(None)
+        self.assertIsNone(x.to_nullable())
+
     def test_map(self):
         x = []
         monad_std.Option.some(2).inspect(lambda s: x.append(s))

--- a/tests/result_test.py
+++ b/tests/result_test.py
@@ -167,6 +167,9 @@ class ResultTest(unittest.TestCase):
             3,
         )
 
+        self.assertEqual(monad_std.Result.of_ok("foo").unwrap_unchecked(),
+                         monad_std.Result.of_err("foo").unwrap_unchecked())
+
     def test_bool(self):
         self.assertEqual(
             monad_std.Result.of_ok(2).bool_and(monad_std.Result.of_err("late error")),


### PR DESCRIPTION
**ADD**

- `monad_std.Option`:
    - `to_nullable`/`unwrap_unchecked`: Convert `Option[T]` to `Optional[T]`.
- `monad_std.Result`:
    - `unwrap_unchecked`: Convert `Result[T, E]` to `Union[T, E]`.

**TEST ENV**

- Add CPython 3.12 as test target.